### PR TITLE
Agrego datasheets PDF a la carpeta DataSheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # EMBEBIDOS-I2C-12025
 ---
 
-## 📂 Datasheets electrónicos agregados (rama SAUL)
+---
+
+##  ~B Datasheets electrónicos agregados (rama SAUL)
 
 Estos documentos se encuentran dentro de la carpeta `DataSheets/`:
 
@@ -9,4 +11,6 @@ Estos documentos se encuentran dentro de la carpeta `DataSheets/`:
 - arduinonano.pdf
 - esp32-wroom-32_datasheet_en.pdf
 - infrarojo.pdf
+
+
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # EMBEBIDOS-I2C-12025
+---
+
+## 📂 Datasheets electrónicos agregados (rama SAUL)
+
+Estos documentos se encuentran dentro de la carpeta `DataSheets/`:
+
+- Leantec.ES-HC-SR04.pdf
+- arduinonano.pdf
+- esp32-wroom-32_datasheet_en.pdf
+- infrarojo.pdf
+


### PR DESCRIPTION
Se agregaron los siguientes archivos PDF en la carpeta DataSheets desde la rama SAUL:

Leantec.ES-HC-SR04.pdf

arduinonano.pdf

esp32-wroom-32_datasheet_en.pdf

infrarojo.pdf

Además, se actualizó el archivo README.md para documentar la lista de datasheets agregados.

Estos cambios fueron realizados en una rama separada (SAUL) para mantener la rama main limpia y organizada.